### PR TITLE
Blur enhancements

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -64,6 +64,8 @@
 	<meta name="if:Click Photo opens Permalink" content="1"/>
 	
 	<meta name="if:Photo in Post Box" content="0"/>
+	
+	<meta name="if:Spoiler Blur on All Pages" content="0"/>
     
     <meta name="if:Show Home" content="1"/>
     <meta name="if:Show Ask" content="1"/>
@@ -301,25 +303,21 @@
         
         .sumac_spoiler {
             {block:ifSpoilerBlurAmount}
-            {block:HomePage}
         	filter: blur({text:Spoiler Blur Amount});
         	-webkit-transition: filter .25s ease-out;
             -moz-transition: filter .25s ease-out;
             -o-transition: filter .25s ease-out;
             transition: filter .25s ease-out;
-        	{/block:HomePage}
         	{/block:ifSpoilerBlurAmoint}
         }
         
         .sumac_spoiler:hover, .sumac_spoiler:focus {
             {block:ifSpoilerBlurAmount}
-            {block:HomePage}
         	filter: blur(0px);
         	-webkit-transition: filter .25s ease-out;
             -moz-transition: filter .25s ease-out;
             -o-transition: filter .25s ease-out;
             transition: filter .25s ease-out;
-        	{/block:HomePage}
         	{/block:ifSpoilerBlurAmount}
         }
         
@@ -357,8 +355,6 @@
                  margin-right: 5px;
              }
         }
-        
-        
         
         .sumac-post-navigation-button {
             position: fixed;
@@ -909,6 +905,22 @@
         function hidePopover() {
             $('#sumac-share-popover').popover('hide');
         }
+        
+        {block:ifRedirectHomePage}
+        {block:HomePage}
+        // Redirect on window load
+        window.onload = function() {
+            window.location.replace('{text:Redirect Home Page}');
+        };
+        {/block:HomePage}
+        {/block:ifRedirectHomePage}
+
+        {block:ifNotSpoilerBlurOnAllPages}
+        // If not page 1, don't blur spoiler content
+        if ({CurrentPage} != 1) {
+            $('.sumac-post-container').removeClass('sumac_spoiler');
+        }
+        {/block:ifNotSpoilerBlurOnAllPages}
     </script>
     
     {block:IfGoogleAnalyticsID}
@@ -937,17 +949,6 @@
 		<a title="Google Analytics Alternative" href="https://getclicky.com/{text:Clicky ID}"></a>
 		<noscript><p><img alt="Clicky" width="1" height="1" src="https://in.getclicky.com/{text:Clicky ID}ns.gif"></p></noscript>
 	{/block:ifClickyID}
-	
-	{block:ifRedirectHomePage}
-	{block:HomePage}
-	<!-- Region - Redirect Script -->
-    <script>
-        window.onload = function() {
-            window.location.replace('{text:Redirect Home Page}');
-        };
-    </script>
-    {/block:HomePage}
-    {/block:ifRedirectHomePage}
 </body>
 
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -64,6 +64,8 @@
 	<meta name="if:Click Photo opens Permalink" content="1"/>
 	
 	<meta name="if:Photo in Post Box" content="0"/>
+	
+	<meta name="if:Spoiler Blur on All Pages" content="0"/>
     
     <meta name="if:Show Home" content="1"/>
     <meta name="if:Show Ask" content="1"/>
@@ -571,7 +573,11 @@
     <script src="js/redirect.min.js"></script>
     {/block:HomePage}
     {/block:ifRedirectHomePage}
-    
+
+    {block:ifNotSpoilerBlurOnAllPages}
+    <script src="js/spoiler.min.js"></script>
+    {/block:ifNotSpoilerBlurOnAllPages}
+
     {block:IfGoogleAnalyticsID}
     <!-- Region - Google Analytics -->
 	<script>

--- a/src/js/spoiler.js
+++ b/src/js/spoiler.js
@@ -1,0 +1,3 @@
+if ({CurrentPage} != 1) {
+    $('.sumac-post-container').removeClass('sumac_spoiler');
+}

--- a/src/js/spoiler.min.js
+++ b/src/js/spoiler.min.js
@@ -1,0 +1,1 @@
+if({CurrentPage}!=1){$('.sumac-post-container').removeClass('sumac_spoiler');}


### PR DESCRIPTION
Resolves #9 

There is now a `Spoiler Blur on All Pages` theme variable. When this variable is disabled, spoiler blur only occurs on page 1. Anything tagged `#sumac-spoiler` on other pages is not blurred.

WIP pending decision on how to make mobile spoilers better. The fix to that will be included in this PR.